### PR TITLE
Add error method to LazyResult

### DIFF
--- a/src/LazyResult.d.ts
+++ b/src/LazyResult.d.ts
@@ -16,6 +16,7 @@ export default class LazyResult<E, T> {
     successCallback: (value: T) => O,
   ): O;
   value(): undefined | T;
+  error(): undefined | E;
 }
 
 export function Initial<E, T>(): LazyResult<E, T>;

--- a/src/LazyResult.js
+++ b/src/LazyResult.js
@@ -125,6 +125,10 @@ export default class LazyResult<E, T> {
     value(): T | void {
         return this.dispatch(nothing, nothing, nothing, x => x);
     }
+
+    error(): E | void {
+        return this.dispatch(nothing, nothing, x => x, nothing);
+    }
 }
 
 const _Initial = <E, T>(): LazyResult<E, T> => LazyResult.initial();

--- a/src/__tests__/LazyResult.test.js
+++ b/src/__tests__/LazyResult.test.js
@@ -67,4 +67,12 @@ describe('LazyResult', () => {
         expect(v3).toBe(undefined);
         expect(v4).toBe('awesome');
     });
+
+    it('error', () => {
+        const [v1, v2, v3, v4] = [r1, r2, r3, r4].map(m => m.error());
+        expect(v1).toBe(undefined);
+        expect(v2).toBe(undefined);
+        expect(v3).toBe('oops');
+        expect(v4).toBe(undefined);
+    });
 });


### PR DESCRIPTION
Having a method to extract the error value from a LazyResult would be very useful to me. In the hope that I'm not alone, I offer this humble pull request. 