### PR TITLE
Fix static methods type definitions

### DIFF
--- a/src/LazyResult.d.ts
+++ b/src/LazyResult.d.ts
@@ -1,8 +1,8 @@
 export default class LazyResult<E, T> {
-  initial(): LazyResult<E, T>;
-  loading(): LazyResult<E, T>;
-  failure(error: E): LazyResult<E, T>;
-  success(value: T): LazyResult<E, T>;
+  static initial<E, T>(): LazyResult<E, T>;
+  static loading<E, T>(): LazyResult<E, T>;
+  static failure<E, T>(error: E): LazyResult<E, T>;
+  static success<E, T>(value: T): LazyResult<E, T>;
 
   toString(): string;
   isInitial(): boolean;

--- a/src/Maybe.d.ts
+++ b/src/Maybe.d.ts
@@ -1,6 +1,6 @@
 export default class Maybe<T> {
-  just(value: T): Maybe<T>;
-  nothing(): Maybe<T>;
+  static just<T>(value: T): Maybe<T>;
+  static nothing<T>(): Maybe<T>;
 
   toString(): string;
   isJust(): boolean;

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -1,6 +1,6 @@
 export default class Result<E, T> {
-  ok(value: T): Result<E, T>;
-  err(error: E): Result<E, T>;
+  static ok<E, T>(value: T): Result<E, T>;
+  static err<E, T>(error: E): Result<E, T>;
 
   toString(): string;
   isOk(): boolean;


### PR DESCRIPTION
Those static methods were wrongly showing up on the instances' members autocomplete. So I fixed it 😁  @nvie 